### PR TITLE
Fix RefSeq downloads to use assembly_summary.txt files.

### DIFF
--- a/designs/tb-amr.ini
+++ b/designs/tb-amr.ini
@@ -1,0 +1,20 @@
+[Sample]
+genome = MycobacteriumTuberculosis
+
+[Genes]
+target_ids = Rv3795,Rv1484,Rv2245,Rv1908c,Rv0667,Rv0682,Rvnr01
+target_names = embB,inhA,kasA,katG,rpoB,rpsL,rrs
+
+[Primers]
+include_tails = False
+F_tail = TTTCTGTTGGTGCTGATATTGC
+R_tail = ACTTGCCTGTCGCTCTATCTTC
+
+[Amplicons]
+min_size_bp = 2000
+max_size_bp = 4000
+primer3_settings = default, stringent, relaxed, variable
+
+[Output]
+name = tb-amr
+primer_code = v

--- a/genomes/collection.ini
+++ b/genomes/collection.ini
@@ -18,3 +18,17 @@ clade = fungi
 genus = candida
 species = albicans
 assembly = GCA000182965v3
+
+[MycobacteriumTuberculosis]
+source = refseq
+clade = bacteria
+genus = mycobacterium
+species = tuberculosis
+assembly = GCF_000195955.2
+
+[SchistosomaMansoni]
+source = refseq
+clade = invertebrate
+genus = schistosoma
+species = mansoni
+assembly = GCF_000237925.1

--- a/src/multiply/download/collection.py
+++ b/src/multiply/download/collection.py
@@ -1,6 +1,6 @@
 import os
 import configparser
-from multiply.util.exceptions import GenomeSourceNotFound
+from multiply.util.exceptions import GenomeCollectionError
 from multiply.util.definitions import ROOT_DIR
 from multiply.download.genomes import PlasmoDBFactory, EnsemblGenomesFactory, RefSeqGenomesFactory
 
@@ -60,7 +60,7 @@ class GenomeCollection(dict):
 
             # Get suitable factory
             if not source in self._factory_names:
-                raise GenomeSourceNotFound(f"No support to download genomes from source '{source}'. "
+                raise GenomeCollectionError(f"No support to download genomes from source '{source}'. "
                                            f" Supported sources: {', '.join(self._factory_names)}."
                                            )
 
@@ -78,8 +78,8 @@ class GenomeCollection(dict):
         
         """
 
-        has_fasta = os.path.isfile(f"{ROOT_DIR}/{self[genome_name].fasta_path}")
-        has_gff = os.path.isfile(f"{ROOT_DIR}/{self[genome_name].gff_path}")
+        has_fasta = os.path.isfile(self[genome_name].fasta_path)
+        has_gff = os.path.isfile(self[genome_name].gff_path)
 
         return has_fasta and has_gff
 

--- a/src/multiply/util/exceptions.py
+++ b/src/multiply/util/exceptions.py
@@ -1,31 +1,46 @@
 class DesignFileError(Exception):
-    """ Error in format or contents of the design file """
+    """Error in format or contents of the design file"""
+
     pass
+
 
 class NoTargetsFoundError(Exception):
-    """ Error finding targets, usually related to GFF """
+    """Error finding targets, usually related to GFF"""
+
     pass
+
 
 class TargetSizeError(Exception):
-    """ Error in size of a target, usually relative to specified parameters """
+    """Error in size of a target, usually relative to specified parameters"""
+
     pass
+
 
 class TargetPositionError(Exception):
-    """ Error in the position of targets, i.e. some overlap """
+    """Error in the position of targets, i.e. some overlap"""
+
     pass
+
 
 class NoPrimerNameException(Exception):
-    """ Raised when the `primer_name` column is missing """
+    """Raised when the `primer_name` column is missing"""
+
     pass
+
 
 class NoPrimersFoundException(Exception):
-    """ Raised  when no primers are found for a target """
+    """Raised  when no primers are found for a target"""
+
     pass
 
-class GenomeSourceNotFound(Exception):
-    """ Raised when a genome source is invalid """
+
+class GenomeCollectionError(Exception):
+    """Error in format or contents of the genome collection file"""
+
     pass
+
 
 class BEDFormattingError(Exception):
-    """ Raised when an input BED file is formatted incorrectly """
+    """Raised when an input BED file is formatted incorrectly"""
+
     pass


### PR DESCRIPTION
I believe this fixes #3. The most important changes are to `class RefSeqGenomesFactory(GenomeFactory)`, where I have introduced methods to download the `assembly_summary.txt` file and then query it to find the appropriate FTP path for a given assembly.