### PR TITLE
Add vectorbase downloader and skip gff plotting when targets dont have nearby features

### DIFF
--- a/genomes/collection.ini
+++ b/genomes/collection.ini
@@ -32,3 +32,17 @@ clade = invertebrate
 genus = schistosoma
 species = mansoni
 assembly = GCF_000237925.1
+
+[AnophelesGambiaePEST]
+source = vectorbase
+release = 68
+genus = anopheles
+species = gambiae
+strain = PEST
+
+[AedesAegypti]
+source = vectorbase
+release = 68
+genus = aedes
+species = aegypti
+strain = LVP_AGWG

--- a/src/multiply/blast/main.py
+++ b/src/multiply/blast/main.py
@@ -43,7 +43,7 @@ def blast(primer_csv, genome_name):
 
     # WRITE PRIMER FASTA, for BLAST input
     primer_dt = dict(zip(primer_df["primer_name"], primer_df["seq"]))
-    primer_fasta = f"{output_dir}/cadidate_primer.fasta"
+    primer_fasta = f"{output_dir}/candidate_primer.fasta"
     write_fasta_from_dict(input_dt=primer_dt, output_fasta=primer_fasta)
 
     # RUN BLAST

--- a/src/multiply/download/collection.py
+++ b/src/multiply/download/collection.py
@@ -2,13 +2,13 @@ import os
 import configparser
 from multiply.util.exceptions import GenomeCollectionError
 from multiply.util.definitions import ROOT_DIR
-from multiply.download.genomes import PlasmoDBFactory, EnsemblGenomesFactory, RefSeqGenomesFactory
+from multiply.download.genomes import PlasmoDBFactory, EnsemblGenomesFactory, RefSeqGenomesFactory, VectorBaseFactory
 
 
 
 
 INI_PATH = f"{ROOT_DIR}/genomes/collection.ini"
-FACTORIES = [PlasmoDBFactory, EnsemblGenomesFactory, RefSeqGenomesFactory]
+FACTORIES = [PlasmoDBFactory, EnsemblGenomesFactory, RefSeqGenomesFactory, VectorBaseFactory]
 
 # ================================================================================
 # Define a collection of Genome objects

--- a/src/multiply/download/fasta.py
+++ b/src/multiply/download/fasta.py
@@ -33,6 +33,7 @@ def convert_fasta_to_all_uppercase(fasta_path: str, dry_run=False) -> None:
 unmask_fasta_info = {
     "plasmodb": False,
     "ensemblgenomes": False,
-    "refseq": True
+    "refseq": True,
+    "vectorbase": False
 }
 

--- a/src/multiply/download/genomes.py
+++ b/src/multiply/download/genomes.py
@@ -100,6 +100,53 @@ class PlasmoDBFactory(GenomeFactory):
 
         return genome
 
+class VectorBaseFactory(GenomeFactory):
+    """
+    Create Genome objects from VectorBase
+
+    """
+
+    source = "vectorbase"
+    source_url = "https://vectorbase.org/common/downloads"
+
+    def create_genome(self, name, genus, species, strain, release, include_variation=None):
+        """Create a genome object from VectorBase"""
+
+        # Process input information
+        lineage = f"{genus.capitalize()[0]}{species.lower()}{strain}"
+
+        # Get URL for species, strain
+        data_url = f"{self.source_url}/release-{release}/{lineage}"
+
+        # Prepare FASTA information
+        fasta_fn = f"VectorBase-{release}_{lineage}_Genome.fasta"
+        fasta_url = f"{data_url}/fasta/data/{fasta_fn}"
+        fasta_raw_download = f"{self.output_dir}/{name}/{fasta_fn}"
+        fasta_path = fasta_raw_download  # already decompressed
+
+        # Prepare GFF information
+        gff_fn = f"VectorBase-{release}_{lineage}.gff"
+        gff_url = f"{data_url}/gff/data/{gff_fn}"
+        gff_raw_download = f"{self.output_dir}/{name}/{gff_fn}"
+        gff_path = gff_raw_download.replace(".gff", ".csv")
+
+        # Create Genome
+        genome = Genome(
+            name=name,
+            source=self.source,
+            fasta_url=fasta_url,
+            fasta_raw_download=fasta_raw_download,
+            fasta_path=fasta_path,
+            gff_url=gff_url,
+            gff_raw_download=gff_raw_download,
+            gff_path=gff_path,
+            include_variation=include_variation
+            if include_variation is not None
+            else "",
+        )
+
+        return genome
+
 
 class EnsemblGenomesFactory(GenomeFactory):
     """
@@ -300,3 +347,5 @@ class RefSeqGenomesFactory(GenomeFactory):
         )
 
         return genome
+
+

--- a/src/multiply/download/gff.py
+++ b/src/multiply/download/gff.py
@@ -194,10 +194,26 @@ def standardise_RefSeqGenomes_gff(gff_df, restrict_to=["gene"], source_only=["Re
     
     return standard_df
 
+def standardise_VectorBaseGenomes_gff(gff_df, restrict_to=["protein_coding_gene"], source_only=["VEuPathDB"]):
+    """
+    Standardise GFF dataframe download from RefSeq Genome database
+    
+    """
+    
+    # Query for relevant features
+    standard_df = gff_df.query("feature in @restrict_to and source in @source_only")
+    standard_df = add_gff_attributes(
+        input_df=standard_df,
+        field_names=["Name", "ID"]
+    )
+    standard_df.rename({"Name": "name"}, axis=1, inplace=True)
+        
+    return standard_df
 
 # Prepare .gff standardisation
 gff_standardisation_functions = {
     "plasmodb": standardise_PlasmoDB_gff,
+    "vectorbase": standardise_VectorBaseGenomes_gff,
     "ensemblgenomes": standardise_EnsemblGenomes_gff,
-    "refseq": standardise_RefSeqGenomes_gff
+    "refseq": standardise_RefSeqGenomes_gff,
 }

--- a/src/multiply/download/gff.py
+++ b/src/multiply/download/gff.py
@@ -196,7 +196,7 @@ def standardise_RefSeqGenomes_gff(gff_df, restrict_to=["gene"], source_only=["Re
 
 def standardise_VectorBaseGenomes_gff(gff_df, restrict_to=["protein_coding_gene"], source_only=["VEuPathDB"]):
     """
-    Standardise GFF dataframe download from RefSeq Genome database
+    Standardise GFF dataframe download from vectorbase database
     
     """
     

--- a/src/multiply/view/main.py
+++ b/src/multiply/view/main.py
@@ -75,6 +75,10 @@ def view(result_dir, genome_name):
         )
         primer_plotter = PrimerPlotter(target_primer_df)
 
+        # if there are no features to plot, skip this site
+        if gff_plotter.plot_gff.shape[0] == 0:
+            continue
+
         # Compose
         comb_plotter = CombinedPlotter(
             sequence_plotter=seq_plotter,

--- a/src/multiply/view/plot.py
+++ b/src/multiply/view/plot.py
@@ -121,7 +121,7 @@ class GffPlotter:
         plot_gff = self.gff.query(qry).query("feature in @self.gff_features")
 
         # Ensure there are some regions
-        assert plot_gff.shape[0] > 0, "No features in this region."
+        #assert plot_gff.shape[0] > 0, "No features in this region."
 
         return plot_gff
 


### PR DESCRIPTION
This PR adds a vectorbase downloader to multiply, allowing users to download reference genomes from vectorbase. This can be handy as some (more obscure) reference genomes are not available on refseq (for example, Anopheles dirus).

We also move some logic in the gff plotting function, so that if a target has no nearby features, that target is skipped, rather than the code stopping completely (which prevents the multiply pipeline from running to completion). This is important, as we often do want to target intergenic snps. 